### PR TITLE
plugin dir config value and install plugins that are in sub dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# generator-craftinstall 
+# generator-craftinstall
 
 generator-craftinstall is a [Yeoman](http://yeoman.io) generator for [Craft CMS](http://www.buildwithcraft.com) installs
 
@@ -144,7 +144,7 @@ A MySQL database dump that we pipe into your new Craft CMS install's database.  
             "src": "craft/db/dump.sql"
         }
     ],
- 
+
 
 * `user:` the user name to use to connect to MySQL
 * `password:` the password to use to connect to MySQL
@@ -157,11 +157,14 @@ By default, generator-craftinstall does not dump a database.
 
 ### CRAFT_PLUGINS
 
+There is a config setting for the plugins directory path. This is `CRAFT_PLUGINS_DIRECTORY` and is set to `craft/plugins` by default.
+
 Craft CMS plugins downloaded from git repositories on github.com
 
 * `name:` The human-readable name of the plugin
 * `url:` the git clone URL for the plugin
-* `path:` the destination path, relative to the project directory
+* `dir:` the plugin directory name
+* `subDirectory:` a boolean value. If `true` this means the plugin is in a sub directory in the vendors repository [e.g. Pixel & Tonic's Contact Form](https://github.com/pixelandtonic/ContactForm)
 
 By default, generator-craftinstall just clones my `Minify`, `Cookies`, and `Path Tools` plugins, but you can change these, or add any plugins you want cloned here.
 
@@ -196,8 +199,8 @@ Here's an example of the output from a `yo craftinstall` generator:
 vagrant@homestead:~/sites/testapp101$ yo craftinstall
 [ Initializing ]
 ? Select which install to use: (Use arrow keys)
-❯ Advanced Craft Install 
-  Basic Craft Install 
+❯ Advanced Craft Install
+  Basic Craft Install
 [ Prompting ]
 ? Application name testapp
 [ Configuring ]
@@ -279,7 +282,7 @@ To git@tastystakes.com:testapp.git
 > End install commands
 + animate.css npm install executed
 > All set.  Have a nice day.
-vagrant@homestead:~/sites/testapp101$ 
+vagrant@homestead:~/sites/testapp101$
 ```
 
 ## Debugging

--- a/app/index.js
+++ b/app/index.js
@@ -283,7 +283,16 @@ module.exports = yo.generators.Base.extend({
         for (var i = 0; i < this.install.CRAFT_PLUGINS.length; i++) {
             var plugin = this.install.CRAFT_PLUGINS[i];
             console.log('+ ' + chalk.green(plugin.name) + ' plugin installed');
-            child_process.execSync('git clone ' + plugin.url + ' ' + plugin.path);
+            var pluginPath = this.install.CRAFT_PLUGINS_DIRECTORY + '/' + plugin.dir;
+            child_process.execSync('git clone ' + plugin.url + ' ' + pluginPath);
+            if (plugin.subDirectory) {
+              console.log('+ ' + chalk.green(plugin.name) + ' moving sub directory');
+              var tmpPluginDir = this.install.CRAFT_PLUGINS_DIRECTORY + '/tmp-' + plugin.dir;
+              child_process.execSync('mv ' + pluginPath + '/' + plugin.dir
+                  + ' ' + tmpPluginDir
+                  + ' && rm -rf ' + pluginPath
+                  + ' && mv ' + tmpPluginDir + ' ' + pluginPath);
+            }
         }
 
         console.log(chalk.green('> Sync to file system'));

--- a/app/templates/advanced_craft_install.json
+++ b/app/templates/advanced_craft_install.json
@@ -71,26 +71,27 @@
     ],
     "MYSQL_DBS": [
     ],
+    "CRAFT_PLUGINS_DIRECTORY": "craft/plugins",
     "CRAFT_PLUGINS": [
         {
             "name": "Minify",
             "url": "https://github.com/khalwat/minify.git",
-            "path": "craft/plugins/minify"
+            "dir": "minify"
         },
         {
             "name": "Cookies",
             "url": "https://github.com/khalwat/cookies.git",
-            "path": "craft/plugins/cookies"
+            "dir": "cookies"
         },
         {
             "name": "Retour",
             "url": "https://github.com/nystudio107/retour.git",
-            "path": "craft/plugins/retour"
+            "dir": "retour"
         },
         {
             "name": "SEOmatic",
             "url": "https://github.com/nystudio107/seomatic.git",
-            "path": "craft/plugins/seomatic"
+            "dir": "seomatic"
         }
     ],
     "REMOTE_GIT_ORIGIN": "",

--- a/app/templates/basic_craft_install.json
+++ b/app/templates/basic_craft_install.json
@@ -51,6 +51,7 @@
     ],
     "MYSQL_DBS": [
     ],
+    "CRAFT_PLUGINS_DIRECTORY": "craft/plugins",
     "CRAFT_PLUGINS": [
     ],
     "REMOTE_GIT_ORIGIN": "",


### PR DESCRIPTION
I had an issue with some plugins as in their respective repos they were stored in a sub directory.

Take [Pixel & Tonic's Contact Form](https://github.com/pixelandtonic/ContactForm) as an example. The actual plugin folder is in a sub directory and therefore didn't add properly.

I added a param to the `CRAFT_PLUGINS` section called `subDirectory` (could probably do with a better name). When this is set to true it will move out the directory to avoid the above stated issue.

This could be a whole lot more clever and actually test for the existence of the directory, therefore negating the need for a flag but this was simply a first pass to get around the issue in the short term.

During the process I also added `CRAFT_PLUGINS_DIRECTORY` option as it removed the need to have information repeated for every plugin. This also lead me to rename the `path` option to `dir` as then that made more sense after the other changes.

Again, this was a relatively quick first pass. So there is plenty of room for improvement, but hopefully it, at bare minimum, highlight the issue I was trying to solve
